### PR TITLE
Update binder config files for JupyterLab

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - scipy
   - matplotlib
   - ipywidgets
+  - jupyterlab>=1.1.0
   - mkl
   - geoana==0.0.5
   - pymatsolver==0.1.2

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,1 @@
+jupyter labextension install @jupyter-widgets/jupyterlab-manager@1.1.0


### PR DESCRIPTION
To get the widgets working in JupyterLab via Binder, we need the jupyterlab-manager extension, but since we also want to be able to support more recently created extensions, updating repo2docker's default JupyterLab is also needed.

* Installs JupyterLab 1.1.x
* Installs jupyterlab-manager 1.1.0

Tested through mybinder.org.